### PR TITLE
Add category classifier API

### DIFF
--- a/opennlp.js
+++ b/opennlp.js
@@ -68,7 +68,23 @@ var openNLP = function(config) {
 					return instance.chunk(javaSentence, tokensArray, cb);
 				}.bind(null, sentence));
 			}
-
+		},
+    doccat: {
+			categorize: function(sentence, cb) {
+				return self.doccat(function(error, instance) {
+					if (typeof sentence == 'string') {
+						sentence = sentence.split(' ');
+					}
+					var javaSentence = self.java.newArray("java.lang.String", sentence);
+					return instance.categorize(javaSentence, cb);
+				});
+			},
+      getBestCategory: function(outcome, cb) {
+				return self.doccat(function(double, error, instance) {
+					var javaDouble = self.java.newArray("double", outcome);
+					return instance.getBestCategory(javaDouble, cb);
+				}.bind(null, outcome));
+			},
 		},
 		instance: self
 	}
@@ -151,6 +167,23 @@ openNLP.prototype.chunker = function(cb) {
 			}
 			return self.java.newInstance('opennlp.tools.chunker.ChunkerME', model, cb)
 		});
+	});
+}
+
+openNLP.prototype.doccat = function(cb) {
+	var self = this;
+	self.java.import('opennlp.tools.doccat.DoccatModel')
+	self.java.import('opennlp.tools.doccat.DocumentCategorizerME')
+	self.java.newInstance('java.io.FileInputStream', self.models.doccat, function(err, fis) {
+		if (err) {
+			return cb(err);
+		}
+		self.java.newInstance('opennlp.tools.doccat.DoccatModel', fis, function(err, model) {
+			if (err) {
+				return cb(err);
+			}
+			self.java.newInstance('opennlp.tools.doccat.DocumentCategorizerME', model, cb)
+		})
 	});
 }
 module.exports = openNLP;


### PR DESCRIPTION
Adds ability to use OpenNLP's category classifier. No model attached obviously but you can create one with the following:

```
opennlp DoccatTrainer -model en-categories.bin -lang en -data categories.trainer -encoding UTF-8
```

Where categories.trainer looks like:

```
movies I loved watching Predators.
books I once read American Pastoral.
```

``` javascript
var options = {
  doccat: __dirname + '/../en-categories.bin'
};

var tagger = (new openNLP(options)).doccat;

tagger.categorize( "I enjoyed watching Rocky", function( err, list ) {
  clothesTagger.getBestCategory( list, function( err, category ) {
    console.log( category );
} );
```
