### PR TITLE
Update package.json to latest java version to enable use on ubuntu 18.04

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "author": "Milos Bejda <mbejda@live.com> (mbejda.com)",
   "license": "The MIT License (MIT)",
   "dependencies": {
-    "extendy": "1.0.1",
-    "java": "0.6.0"
+    "extendy": "^1.0.1",
+    "java": "^0.11.0"
   },
   "devDependencies": {
     "jasmine-node": "^1.14.5"


### PR DESCRIPTION
Updated java version dependency. This closes mbejda#14.